### PR TITLE
Add sticks and throttles option for saitek rhino pro x55/56 and input-remapper

### DIFF
--- a/wiki/Sticks,-Throttles,-&-Pedals.md
+++ b/wiki/Sticks,-Throttles,-&-Pedals.md
@@ -34,11 +34,24 @@ Requires a windows-only software for calibration and configuration. [Link](https
     
 Requires a windows-only software for calibration and configuration. [Link; scroll down](https://support.virpil.com/en/support/solutions)
 
+## Saitek H.O.T.A.S Rhino Pro X55/X56
+
+For X55/56 can be used the [input-remapper](https://github.com/sezanzeb/input-remapper), this tool will detect your Sitck and Throttle inmediately and you can create profiles for it at once.
+
+Basic examples profiles can be downloaded at:
+
+[Stick](https://github.com/starcitizen-lug/mappings/blob/main/input-remapper/saitek-rhino-55/StarCitizenStick.json)
+
+[Throttle](https://github.com/starcitizen-lug/mappings/blob/main/input-remapper/saitek-rhino-55/StarCitizenThrottle.json)
+
+
 ## Configuration Tips
 
 ### Mappings
 
 A collection of mappings used by our members can be found [here](https://github.com/starcitizen-lug/mappings).
+
+If you need a generic mapper for different devices consider also the use of [input-remapper](https://github.com/sezanzeb/input-remapper).
 
 ### Evdev Deadzones
 


### PR DESCRIPTION
This MR does the following:

- Add option for configuration of Saitek Rhino pro X55/X56 
- Add recommendation in mappings section to other devices

Dependency: 

This MR depends of the approval for:

https://github.com/starcitizen-lug/mappings/pull/1
