### PR TITLE
DLSS libcuda.so: Automate finding 64-bit libcuda.so and patching

### DIFF
--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -295,7 +295,7 @@
    - A possible solution would be patching LibCUDA file increasing this area.
       - Run this command line to patch a existing 64-bit `libcuda.so` and output the patched library in the shell's current directory for use with the game, will work in extended POSIX shells like bash and zsh, dash(**pure POSIX(printf)**) and fish(**not POSIX(${})**) won't work,
          ```sh
-         CUDALIB="$(ldconfig -p | grep -om1 "86-64.*libcuda.so.*")" printf "$(od -An -tx1 -v "${CUDALIB##* }" | tr -d '\n' | sed -e 's/00 00 00 f8 ff 00 00 00/00 00 00 f8 ff ff 00 00/g' -e 's/ /\\x/g')" > libcuda.patched.so
+         CUDALIB="$(ldconfig -p | grep -m1 "86-64.*libcuda.so")"; printf "$(od -An -tx1 -v "${CUDALIB##* }" | tr -d '\n' | sed -e 's/00 00 00 f8 ff 00 00 00/00 00 00 f8 ff ff 00 00/g' -e 's/ /\\x/g')" > libcuda.patched.so
          ```
       - Use the environment variable `LD_PRELOAD` to load the patched version, for example: `LD_PRELOAD=/path/to/the/libcuda.patched.so:$LD_PRELOAD`
       - Don't forget to enable DXVK-NVAPI.

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -293,7 +293,7 @@
 #### DLSS(Deep Learning Super Sampling) / Vulkan
 - There is a [memory allocation issue with LibCUDA](https://github.com/jp7677/dxvk-nvapi/issues/174#issuecomment-2227462795), where it attempts to allocate in a specific area already occupied by the game.
    - A possible solution would be patching LibCUDA file increasing this area.
-      - Run this command line to patch a existing 64-bit `libcuda.so` and output the patched library in the shell's current directory for use with the game, will work in extended POSIX shells like bash and zsh, dash(pure POSIX(printf)) and fish(not POSIX(${})) won't work,
+      - Run this command line to patch a existing 64-bit `libcuda.so` and output the patched library in the shell's current directory for use with the game, will work in extended POSIX shells like bash and zsh, dash(**pure POSIX(printf)**) and fish(**not POSIX(${})**) won't work,
          ```sh
          CUDALIB="$(ldconfig -p | grep -om1 "86-64.*libcuda.so.*")" printf "$(od -An -tx1 -v "${CUDALIB##* }" | tr -d '\n' | sed -e 's/00 00 00 f8 ff 00 00 00/00 00 00 f8 ff ff 00 00/g' -e 's/ /\\x/g')" > libcuda.patched.so
          ```

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -293,7 +293,10 @@
 #### DLSS(Deep Learning Super Sampling) / Vulkan
 - There is a [memory allocation issue with LibCUDA](https://github.com/jp7677/dxvk-nvapi/issues/174#issuecomment-2227462795), where it attempts to allocate in a specific area already occupied by the game.
    - A possible solution would be patching LibCUDA file increasing this area.
-      - Copy the 64-bit `libcuda.so`(usually `/usr/lib` or run `whereis libcuda.so`) to any directory and run the command `echo -ne $(od -An -tx1 -v libcuda.so | tr -d '\n' | sed -e 's/00 00 00 f8 ff 00 00 00/00 00 00 f8 ff ff 00 00/g' -e 's/ /\\x/g') > libcuda.patched.so` to generate the patched version(`libcuda.patched.so`).
+      - Run this command line to patch a existing 64-bit `libcuda.so` and output the patched library in the shell's current directory for use with the game, will work in extended POSIX shells like bash and zsh, dash(pure POSIX(printf)) and fish(not POSIX(${})) won't work,
+         ```sh
+         CUDALIB="$(ldconfig -p | grep -om1 "86-64.*libcuda.so.*")" printf "$(od -An -tx1 -v "${CUDALIB##* }" | tr -d '\n' | sed -e 's/00 00 00 f8 ff 00 00 00/00 00 00 f8 ff ff 00 00/g' -e 's/ /\\x/g')" > libcuda.patched.so
+         ```
       - Use the environment variable `LD_PRELOAD` to load the patched version, for example: `LD_PRELOAD=/path/to/the/libcuda.patched.so:$LD_PRELOAD`
       - Don't forget to enable DXVK-NVAPI.
 


### PR DESCRIPTION
Use a environment variable, `ldconfig`, `grep` and a POSIX `sh` method to get the file path to the 64-bit library.
1. `ldconfig -p` to get a list and path of libraries the system has and marks them 64-bit
2. `grep -om1 "86-64.*libcuda.so.*"` to find a single 64-bit library and omit unneeded charactors
3. `${CUDALIB##* }` POSIX sh method to get position arguments in a variable
4. changed `echo -ne` with `printf` as it is much faster

Could be simplified further using `xxd` but this belongs to `vim`
Supports extended POSIX shells, `dash` is more pure POSIX and has different behavior with `printf`, arguments with `echo` in pure POSIX are undefined and also don't work, fish isn't POSIX and doesn't work with either as well as not supporting `${}`