### PR TITLE
Update quick start guide for Helper 3.0

### DIFF
--- a/wiki/Quick-Start-Guide.md
+++ b/wiki/Quick-Start-Guide.md
@@ -7,7 +7,7 @@ New to Linux? See our [Recommended Distributions](Tips-and-Tricks#recommended-di
 4. If you want to install without Lutris, install DXVK from your distro's repository.
 
 ## Installation Steps
-1. Download our [LUG Helper](https://github.com/starcitizen-lug/lug-helper/releases/latest) (distro packages listed [here](https://github.com/starcitizen-lug/lug-helper#installation)).
+1. Download our [LUG Helper](https://github.com/starcitizen-lug/lug-helper/releases/latest) (Select the `.tar.gz`. Distro packages listed [here](https://github.com/starcitizen-lug/lug-helper#installation))
 2. Launch the LUG Helper and select your preferred installation method: `Install Star Citizen with Lutris/Wine`.
 3. Allow the Preflight Check to fix any issues it finds before proceeding!
 4. Select an install location on an SSD where you have space for the entire game, approximately 110GB (we do not recommend an HDD).  

--- a/wiki/Quick-Start-Guide.md
+++ b/wiki/Quick-Start-Guide.md
@@ -2,20 +2,17 @@
 New to Linux? See our [Recommended Distributions](Tips-and-Tricks#recommended-distros) for a list of the distros most compatible with Star Citizen.
 
 1. Install wine following the instructions for your distro on the [WineHQ website](https://wiki.winehq.org/Category:Distributions). **If your distro provides an up to date version of wine** (ie. Arch), you may install from its repos instead. See the [WineHQ Main Page](https://www.winehq.org/) for current versions.
-2. Install [32 bit drivers](Troubleshooting#-32bit-drivers) for your graphics card.
-3. Install [Lutris **v0.5.11**](https://lutris.net/downloads/) or newer and launch it once before installing Star Citizen to trigger its automatic winetricks dependency download. **Note**: We do not recommend running git builds of Lutris.
-4. In Lutris' `Preferences->Global options`, `Prefer system libraries` may have to be toggled to either `On` or `Off` depending on your system. For most distros, this should be `On`. After installation is successful, this may be reset or configured on a per-game basis as needed.
+2. Install [Lutris **v0.5.17**](https://lutris.net/downloads/) or newer and launch it once before installing Star Citizen to trigger its automatic winetricks dependency download. **Note**: We do not recommend running git builds of Lutris.
+3. In Lutris' `Preferences->Global options`, `Prefer system libraries` may have to be toggled to either `On` or `Off` depending on your system. For most distros, this should be `On`. After installation is successful, this may be reset or configured on a per-game basis as needed.
 
 ## Installation Steps
 1. Download our [LUG Helper](https://github.com/starcitizen-lug/lug-helper/releases/latest) (distro packages listed [here](https://github.com/starcitizen-lug/lug-helper#installation)).
 2. Launch the LUG Helper and run the `Pre-flight Check` to optimize your system settings.
 3. In the LUG Helper, select `Install Star Citizen` and install the launcher to an SSD where you have space for the entire game, approximately 110GB (we do not recommend an HDD).
 4. Run the RSI launcher from Lutris and finish installing the game; do not change the default install path in the RSI Launcher settings.
-5. In the LUG Helper, select `Manage Lutris Runners`, and install the latest runner from GloriousEggroll (or ask us on our [social channels](https://github.com/starcitizen-lug/knowledge-base/wiki#welcome-space-penguins) which runner is currently recommended).
-6. In the LUG Helper, select `Manage DXVK Versions`. Install the latest standard dxvk.
-7. **Wayland users:** See [required workarounds](https://github.com/starcitizen-lug/knowledge-base/wiki/Troubleshooting#mousecursor-issues-and-view-snapping-in-interaction-mode) to **resolve mouse cursor and view snapping issues when holding F key**
-8. Check our [latest news](https://github.com/starcitizen-lug/knowledge-base/wiki#news) for important updates. Especially, Nvidia gpu driver issues, necessary workarounds, and currently recommended runner/DXVK versions.
-9. Run the launcher again and start the game. See you in the 'verse!
+5. **Wayland users:** See [required workarounds](https://github.com/starcitizen-lug/knowledge-base/wiki/Troubleshooting#mousecursor-issues-and-view-snapping-in-interaction-mode) to resolve mouse cursor and view snapping issues when holding F key.
+6. Check our [latest news](https://github.com/starcitizen-lug/knowledge-base/wiki#news) for important updates. Especially, Nvidia gpu driver issues and necessary workarounds.
+7. Run the launcher again and start the game. See you in the 'verse!
 
 ## Important Information
 > Questions or Problems? Check our [Troubleshooting Guide](Troubleshooting) or ask for help in one of our [social channels](https://github.com/starcitizen-lug/knowledge-base/wiki#welcome-space-penguins)!

--- a/wiki/Quick-Start-Guide.md
+++ b/wiki/Quick-Start-Guide.md
@@ -8,16 +8,17 @@ New to Linux? See our [Recommended Distributions](Tips-and-Tricks#recommended-di
 
 ## Installation Steps
 1. Download our [LUG Helper](https://github.com/starcitizen-lug/lug-helper/releases/latest) (distro packages listed [here](https://github.com/starcitizen-lug/lug-helper#installation)).
-2. Launch the LUG Helper and run the `Pre-flight Check` to optimize your system settings.
-3. In the LUG Helper, select your preferred installation method: `Install Star Citizen with Lutris/Wine`
+2. Launch the LUG Helper and select your preferred installation method: `Install Star Citizen with Lutris/Wine`.
+3. Allow the Preflight Check to fix any issues it finds before proceeding!
 4. Select an install location on an SSD where you have space for the entire game, approximately 110GB (we do not recommend an HDD).
-5. In the RSI Launcher, log in and click install to finish installing the game.  
+5. If using the Wine (non-Lutris) install method, unselect `Run RSI Launcher` when the installer finishes. Instead, follow the LUG Helper's instructions to launch the game.
+6. In the RSI Launcher, log in and click install to finish installing the game.  
  **Do not change the default install path in the RSI Launcher settings!**
-6. Lutris will use umu/Proton by default. Optionally switch to your System Wine version instead:  
+7. Lutris will use umu/Proton by default. Optionally switch to your System Wine version instead:  
   `Right click the game -> Configure -> Runner options -> Wine version`
-7. **Wayland users:** See [required workarounds](https://github.com/starcitizen-lug/knowledge-base/wiki/Troubleshooting#mousecursor-issues-and-view-snapping-in-interaction-mode) to resolve mouse cursor and view snapping issues.
-8. Check our [latest news](https://github.com/starcitizen-lug/knowledge-base/wiki#news) for important updates. Especially, Nvidia gpu driver issues and necessary workarounds.
-9. Run the launcher and start the game. See you in the 'verse!
+8. **Wayland users:** See [required workarounds](https://github.com/starcitizen-lug/knowledge-base/wiki/Troubleshooting#mousecursor-issues-and-view-snapping-in-interaction-mode) to resolve mouse cursor and view snapping issues.
+9. Check our [latest news](https://github.com/starcitizen-lug/knowledge-base/wiki#news) for important updates. Especially, Nvidia gpu driver issues and necessary workarounds.
+10. Run the launcher and start the game. See you in the 'verse!
 
 
 > [!tip]

--- a/wiki/Quick-Start-Guide.md
+++ b/wiki/Quick-Start-Guide.md
@@ -10,15 +10,14 @@ New to Linux? See our [Recommended Distributions](Tips-and-Tricks#recommended-di
 1. Download our [LUG Helper](https://github.com/starcitizen-lug/lug-helper/releases/latest) (distro packages listed [here](https://github.com/starcitizen-lug/lug-helper#installation)).
 2. Launch the LUG Helper and select your preferred installation method: `Install Star Citizen with Lutris/Wine`.
 3. Allow the Preflight Check to fix any issues it finds before proceeding!
-4. Select an install location on an SSD where you have space for the entire game, approximately 110GB (we do not recommend an HDD).
-5. If using the Wine (non-Lutris) install method, unselect `Run RSI Launcher` when the installer finishes. Instead, follow the LUG Helper's instructions to launch the game.
-6. In the RSI Launcher, log in and click install to finish installing the game.  
- **Do not change the default install path in the RSI Launcher settings!**
-7. Lutris will use umu/Proton by default. Optionally switch to your System Wine version instead:  
-  `Right click the game -> Configure -> Runner options -> Wine version`
-8. **Wayland users:** See [required workarounds](https://github.com/starcitizen-lug/knowledge-base/wiki/Troubleshooting#mousecursor-issues-and-view-snapping-in-interaction-mode) to resolve mouse cursor and view snapping issues.
-9. Check our [latest news](https://github.com/starcitizen-lug/knowledge-base/wiki#news) for important updates. Especially, Nvidia gpu driver issues and necessary workarounds.
-10. Run the launcher and start the game. See you in the 'verse!
+4. Select an install location on an SSD where you have space for the entire game, approximately 110GB (we do not recommend an HDD).  
+ **Do not change the default windows install path in the RSI Launcher Setup!**  
+   Leave it set to `C:\Program Files\Roberts Space Industries\RSI Launcher`
+5. If using the Wine (non-Lutris) install method, deselect `Run RSI Launcher` when the setup finishes. Instead, follow the LUG Helper's instructions to launch the game.
+6. In the RSI Launcher, log in and click install to finish installing the game.
+7. **Wayland users:** See [required workarounds](https://github.com/starcitizen-lug/knowledge-base/wiki/Troubleshooting#mousecursor-warp-issues-and-view-snapping-in-interaction-mode) to resolve mouse cursor and view snapping issues.
+8. Check our [latest news](https://github.com/starcitizen-lug/knowledge-base/wiki#news) for important updates. Especially, Nvidia gpu driver issues and necessary workarounds.
+9. Run the launcher and start the game. See you in the 'verse!
 
 
 > [!tip]

--- a/wiki/Quick-Start-Guide.md
+++ b/wiki/Quick-Start-Guide.md
@@ -2,20 +2,27 @@
 New to Linux? See our [Recommended Distributions](Tips-and-Tricks#recommended-distros) for a list of the distros most compatible with Star Citizen.
 
 1. Install wine following the instructions for your distro on the [WineHQ website](https://wiki.winehq.org/Category:Distributions). **If your distro provides an up to date version of wine** (ie. Arch), you may install from its repos instead. See the [WineHQ Main Page](https://www.winehq.org/) for current versions.
-2. Install [Lutris **v0.5.17**](https://lutris.net/downloads/) or newer and launch it once before installing Star Citizen to trigger its automatic winetricks dependency download. **Note**: We do not recommend running git builds of Lutris.
-3. In Lutris' `Preferences->Global options`, `Prefer system libraries` may have to be toggled to either `On` or `Off` depending on your system. For most distros, this should be `On`. After installation is successful, this may be reset or configured on a per-game basis as needed.
+2. Install Winetricks from your distro's repository. Additional instructions are on the [Winetricks github](https://github.com/Winetricks/winetricks?tab=readme-ov-file#installing).
+3. If you want to use Lutris, install [Lutris **v0.5.17**](https://lutris.net/downloads/) or newer and launch it once before installing Star Citizen to trigger its automatic winetricks dependency download. **Note**: We do not recommend running git builds of Lutris.
+4. If you want to install without Lutris, install DXVK from your distro's repository.
 
 ## Installation Steps
 1. Download our [LUG Helper](https://github.com/starcitizen-lug/lug-helper/releases/latest) (distro packages listed [here](https://github.com/starcitizen-lug/lug-helper#installation)).
 2. Launch the LUG Helper and run the `Pre-flight Check` to optimize your system settings.
-3. In the LUG Helper, select `Install Star Citizen` and install the launcher to an SSD where you have space for the entire game, approximately 110GB (we do not recommend an HDD).
-4. Run the RSI launcher from Lutris and finish installing the game; do not change the default install path in the RSI Launcher settings.
-5. **Wayland users:** See [required workarounds](https://github.com/starcitizen-lug/knowledge-base/wiki/Troubleshooting#mousecursor-issues-and-view-snapping-in-interaction-mode) to resolve mouse cursor and view snapping issues when holding F key.
-6. Check our [latest news](https://github.com/starcitizen-lug/knowledge-base/wiki#news) for important updates. Especially, Nvidia gpu driver issues and necessary workarounds.
-7. Run the launcher again and start the game. See you in the 'verse!
+3. In the LUG Helper, select your preferred installation method: `Install Star Citizen with Lutris/Wine`
+4. Select an install location on an SSD where you have space for the entire game, approximately 110GB (we do not recommend an HDD).
+5. In the RSI Launcher, log in and click install to finish installing the game.  
+ **Do not change the default install path in the RSI Launcher settings!**
+6. Lutris will use umu/Proton by default. Optionally switch to your System Wine version instead:  
+  `Right click the game -> Configure -> Runner options -> Wine version`
+7. **Wayland users:** See [required workarounds](https://github.com/starcitizen-lug/knowledge-base/wiki/Troubleshooting#mousecursor-issues-and-view-snapping-in-interaction-mode) to resolve mouse cursor and view snapping issues.
+8. Check our [latest news](https://github.com/starcitizen-lug/knowledge-base/wiki#news) for important updates. Especially, Nvidia gpu driver issues and necessary workarounds.
+9. Run the launcher and start the game. See you in the 'verse!
 
-## Important Information
+
+> [!tip]
 > Questions or Problems? Check our [Troubleshooting Guide](Troubleshooting) or ask for help in one of our [social channels](https://github.com/starcitizen-lug/knowledge-base/wiki#welcome-space-penguins)!
 
-> On first launch, the game will stutter with low FPS while shaders are compiled and caches are filled. As you run/fly around and travel to different places, performance will increase.
+> [!note]
+> On first launch, you may see low FPS while shaders are compiled and caches are filled.  
 > This can also occur after updating Star Citizen, your graphics driver, Wine, or DXVK.


### PR DESCRIPTION
Preparation for when we switch the Helper over to proton installs by default. Also includes requirements and steps for non-lutris installs.