### PR TITLE
Add notice about the merge of the opentrack-StarCitizen repo with Opentrack Master

### DIFF
--- a/wiki/Head-Tracking.md
+++ b/wiki/Head-Tracking.md
@@ -22,7 +22,7 @@
 > `GE Proton (Latest)` is the new umu Proton runner and the official Opentrack builds do not currently work with umu. We have reactivated the [opentrack-StarCitizen repo](https://github.com/Priton-CE/opentrack-StarCitizen) to provide this support.
 > UPDATE: As of 03.10.2024 relevant changes have been merged with the official [Opentrack Master branch](https://github.com/opentrack/opentrack/tree/master). You may use Opentrack Master instead tho be aware that it may be less stable than opentrack-StarCitizen until the next stable and official release of Opentrack.
 > - For `system wine`, `wine-staging`, or `wine-GE-Proton8-x`, use an official Opentrack build version 2023.1.0 or later.
-> - For any `GE-Proton` or `Proton` Runner, follow the [build instructions](https://github.com/Priton-CE/opentrack-StarCitizen?tab=readme-ov-file#building-from-source) on our opentrack-StarCitizen repo. (Or follow the [build instructions](https://github.com/opentrack/opentrack/wiki/Building-on-Linux) for Opentrack Master.)
+> - For any `GE-Proton` or `Proton` Runner, follow the [build instructions](https://github.com/Priton-CE/opentrack-StarCitizen?tab=readme-ov-file#building-from-source) on our opentrack-StarCitizen repo, follow the [build instructions](https://github.com/opentrack/opentrack/wiki/Building-on-Linux) for Opentrack Master or use the [Opentrack Master Git AUR package](https://aur.archlinux.org/packages/opentrack-git).
 
 After installing Opentrack according to the above note, use the following configuration:
 

--- a/wiki/Head-Tracking.md
+++ b/wiki/Head-Tracking.md
@@ -19,9 +19,10 @@
 
 ## Opentrack Configuration
 > [!important]
-> `GE Proton (Latest)` is the new umu Proton runner and the official Opentrack builds do not currently work with umu. We have reactivated the [opentrack-StarCitizen Repo](https://github.com/Priton-CE/opentrack-StarCitizen) to provide this support.
+> `GE Proton (Latest)` is the new umu Proton runner and the official Opentrack builds do not currently work with umu. We have reactivated the [opentrack-StarCitizen repo](https://github.com/Priton-CE/opentrack-StarCitizen) to provide this support.
+> UPDATE: As of 03.10.2024 relevant changes have been merged with the official [Opentrack Master branch](https://github.com/opentrack/opentrack/tree/master). You may use Opentrack Master instead tho be aware that it may be less stable than opentrack-StarCitizen until the next stable and official release of Opentrack.
 > - For `system wine`, `wine-staging`, or `wine-GE-Proton8-x`, use an official Opentrack build version 2023.1.0 or later.
-> - For any `GE-Proton` or `Proton` Runner, follow the [build instructions](https://github.com/Priton-CE/opentrack-StarCitizen?tab=readme-ov-file#building-from-source) on our opentrack-StarCitizen Repo.
+> - For any `GE-Proton` or `Proton` Runner, follow the [build instructions](https://github.com/Priton-CE/opentrack-StarCitizen?tab=readme-ov-file#building-from-source) on our opentrack-StarCitizen repo. (Or follow the [build instructions](https://github.com/opentrack/opentrack/wiki/Building-on-Linux) for Opentrack Master.)
 
 After installing Opentrack according to the above note, use the following configuration:
 

--- a/wiki/Head-Tracking.md
+++ b/wiki/Head-Tracking.md
@@ -22,7 +22,7 @@
 > `GE Proton (Latest)` is the new umu Proton runner and the official Opentrack builds do not currently work with umu. We have reactivated the [opentrack-StarCitizen repo](https://github.com/Priton-CE/opentrack-StarCitizen) to provide this support.
 > UPDATE: As of 03.10.2024 relevant changes have been merged with the official [Opentrack Master branch](https://github.com/opentrack/opentrack/tree/master). You may use Opentrack Master instead tho be aware that it may be less stable than opentrack-StarCitizen until the next stable and official release of Opentrack.
 > - For `system wine`, `wine-staging`, or `wine-GE-Proton8-x`, use an official Opentrack build version 2023.1.0 or later.
-> - For any `GE-Proton` or `Proton` Runner, follow the [build instructions](https://github.com/Priton-CE/opentrack-StarCitizen?tab=readme-ov-file#building-from-source) on our opentrack-StarCitizen repo, follow the [build instructions](https://github.com/opentrack/opentrack/wiki/Building-on-Linux) for Opentrack Master or use the [Opentrack Master Git AUR package](https://aur.archlinux.org/packages/opentrack-git).
+> - For any `GE-Proton` or `Proton` Runner, follow the [build instructions](https://github.com/Priton-CE/opentrack-StarCitizen?tab=readme-ov-file#building-from-source) on our opentrack-StarCitizen repo, follow the [build instructions](https://github.com/opentrack/opentrack/wiki/Building-on-Linux) for Opentrack Master, or use the [Opentrack Master Git AUR package](https://aur.archlinux.org/packages/opentrack-git).
 
 After installing Opentrack according to the above note, use the following configuration:
 


### PR DESCRIPTION
The opentrack-StarCitizen repo has been merged with Opentrack Master. So it may be used instead. This may be beneficial for the people making use of the AUR packages of Opentrack instead.