### PR TITLE
Update Heroic install guide

### DIFF
--- a/wiki/Alternative-Installations.md
+++ b/wiki/Alternative-Installations.md
@@ -85,14 +85,13 @@ If you have trouble installing recent Wine versions on a Debian-based distro due
 1. Download latest [Star Citizen installer](https://robertsspaceindustries.com/download).
 2. Install [Heroic Games Launcher](https://heroicgameslauncher.com/downloads).
 3. Launch Heroic, browse to `Wine Manager>Proton-GE` and install `Proton-GE-Latest`.
-4. Browse to Settings/Advanced and tick `Use UMU as Proton runtime`.
-5. Return to the Library page, and click Add Game.
-6. Set Title to `Star Citizen`.
-7. Click `Show Wine Settings` and ensure Wine Version is set to `Proton-GE-Latest`.
-8. Click `Run Installer First` and select the Star Citizen install file.
-9. Once install is complete, set `Select Executable` to the `RSI Launcher.exe` and click Finish.
-10. Open the game settings in Heroic, change to Advanced tab and under Environment Variables add `GAMEID=umu-starcitizen`.
-11. Run the RSI Launcher, log in, and click install to finish installing the game.
+4. Return to the Library page, and click Add Game.
+5. Set Title to `Star Citizen`.
+6. Click `Show Wine Settings` and ensure Wine Version is set to `Proton-GE-Latest`.
+7. Click `Run Installer First` and select the Star Citizen install file.
+8. Once install is complete, set `Select Executable` to the `RSI Launcher.exe` and click Finish.
+9. Open the game settings in Heroic, change to Advanced tab and under Environment Variables add `GAMEID=umu-starcitizen`.
+10. Run the RSI Launcher, log in, and click install to finish installing the game.
 
 ### Steam
 > [!warning]


### PR DESCRIPTION
Heroic 2.16.0 enabled UMU by default, so no longer needs to be manually toggled.