### PR TITLE
Update wiki tips & alternative installation sections for Nix

### DIFF
--- a/wiki/Alternative-Installations.md
+++ b/wiki/Alternative-Installations.md
@@ -88,6 +88,17 @@ flatpak install -y --user --noninteractive RSILauncher io.github.mactan_sc.RSILa
 flatpak run io.github.mactan_sc.RSILauncher
 ```
 
+## Nix Installation
+Flake: nix-citizen - https://github.com/LovingMelody/nix-citizen
+
+nix-citizen is available for Nix users to install. Please see the repository for instructions. This flake provides a module to configure your NixOS config for running Star Citizen. Packages for both standard wine and proton methods are available. To try without adding anything to your configuration, you can use the following command:
+
+```bash
+nix run github:LovingMelody/nix-citizen#star-citizen
+```
+
+If you prefer not to use nix, the [Flatpak method](#flatpak-installation) would be recommended.
+
 ## Alternate Launchers
 
 > [!warning]

--- a/wiki/Tips-and-Tricks.md
+++ b/wiki/Tips-and-Tricks.md
@@ -80,6 +80,7 @@ boot.kernel.sysctl = {
 };
 ```
 
+Custom wine runners will not work out of the box if the system wine install does not work ( `wineWow64Packages.stableFull` recommended) try `wine-astral` from [nix-citizen](https://github.com/LovingMelody/nix-citizen) or one of the [Alternative Installation](Alternative-Installations#nix) methods.
 
 ## RSI Launcher 2.0
 - Requires standard Wine 9.4+ or Proton GE 9-13+ runner


### PR DESCRIPTION
* Added nix-citizen to alternative installations. Flatpaks have been recommended as an alternative to this

* Add comments about system wine & custom runners not working in Tips and Tricks.