### PR TITLE
Update NVIDIA driver recommendation in troubleshooting

### DIFF
--- a/wiki/Troubleshooting/nvidia.md
+++ b/wiki/Troubleshooting/nvidia.md
@@ -74,7 +74,6 @@ or
    ```
    export DXVK_NVAPI_SET_NGX_DEBUG_OPTIONS="DLSSIndicator=1,DLSSGIndicator=1"
    ```
-7. Note that nvidia driver v575 may be unstable. v570 is recommended for stability.
 
 
 ## Gamescope not working


### PR DESCRIPTION
Removed, since it's no longer true. Many NVIDIA users (e.g., Melody, vertex) have Vulkan working with the current driver.