### PR TITLE
Fix typo in sys_maxIdleFps setting

### DIFF
--- a/wiki/Tips-and-Tricks.md
+++ b/wiki/Tips-and-Tricks.md
@@ -184,7 +184,7 @@ Varibles set using the in-game console must be reapplied each session. Create a 
 
 # Limit frame rate
 # sys_MaxFPS = 120
-# sysmaxidleFPS = 120
+# sys_maxIdleFps = 120
 
 # Toggle vsync
 # r_VSync = 0


### PR DESCRIPTION
Fix the name in `USER.cfg` from `sysmaxIdleFps` to `sys_maxIdleFps`