### PR TITLE
fix internal links to mouse-keyboard-issues

### DIFF
--- a/wiki/Quick-Start-Guide.md
+++ b/wiki/Quick-Start-Guide.md
@@ -35,9 +35,9 @@ nav_order: 2
 ## After Installation
 
 {: .important }
-> - For non-US keyboards, set your [keyboard layout](Troubleshooting/unexpected-behavior#non-us-keyboard-keys-not-working) to resolve issues with game console and accept/reject buttons
+> - For non-US keyboards, set your [keyboard layout](Troubleshooting/mouse-keyboard-issues#non-us-keyboard-keys-not-working) to resolve issues with game console and accept/reject buttons
 > - Set up your peripherals: See [Sticks, Throttles, & Pedals](Sticks,-Throttles,-&-Pedals)
-> - Wayland users: See [required workarounds](Troubleshooting/unexpected-behavior#mousecursor-warp-issues-and-view-snapping-in-interaction-mode) to resolve mouse cursor and view snapping issues.
+> - Wayland users: See [required workarounds](Troubleshooting/mouse-keyboard-issues#mousecursor-warp-issues-and-view-snapping-in-interaction-mode) to resolve mouse cursor and view snapping issues.
 > - Nvidia users: See [troubleshooting guide](Troubleshooting/nvidia#severe-frame-drops) to resolve severe frame drop issues.
 > - Check our [latest news](/#news) for necessary workarounds, Nvidia gpu driver problems, and other important issues.
 

--- a/wiki/Tips-and-Tricks.md
+++ b/wiki/Tips-and-Tricks.md
@@ -145,7 +145,7 @@ Use the [LUG Helper](#how-to-run-the-lug-helper) tool's `Manage DXVK` button
 
 
 ## Console Variables
-Below are some useful console variables. Tap the grave/backtick/tilde key (above tab) to open the console. See our troubleshooting page for [non-US keyboards](Troubleshooting/unexpected-behavior#non-us-keyboard-keys-not-working) if you have trouble opening the console.
+Below are some useful console variables. Tap the grave/backtick/tilde key (above tab) to open the console. See our troubleshooting page for [non-US keyboards](Troubleshooting/mouse-keyboard-issues#non-us-keyboard-keys-not-working) if you have trouble opening the console.
 - `r_displayinfo` [ 1, 2, 3, 0 ]
   - show fps and other details
 - `r_displaysessioninfo` [ 1, 0 ] 


### PR DESCRIPTION
Fix links to the troubleshooting sub-page `mouse-keyboard-issues`.

At some point the mouse and keyboard issues were moved out of the `unexpected-behavior` sub-page, but the links were not updated.