### PR TITLE
Update HDR instructions in Tips-and-Tricks.md

### DIFF
--- a/wiki/Tips-and-Tricks.md
+++ b/wiki/Tips-and-Tricks.md
@@ -245,7 +245,7 @@ Varibles set using the in-game console must be reapplied each session. Create a 
 ## HDR (High Dynamic Range)
 - Requires experimental native [Wayland](Tips-and-Tricks#wine-wayland) or [Gamescope](Tips-and-Tricks#gamescope)
 - To enable HDR in native Wayland:
-  1. Run `wayland-info | grep color` in a terminal. If you **do not** see `wp_color_manager_v1` or if you use an Nvidia gpu, then you will need to install [VK_hdr_layer](https://github.com/Zamundaaa/VK_hdr_layer) and add the environment variable `ENABLE_HDR_WSI=1`
+  1. Run `wayland-info | grep color` in a terminal. If you **do not** see `wp_color_manager_v1` then you will need to install [VK_hdr_layer](https://github.com/Zamundaaa/VK_hdr_layer) and add the environment variable `ENABLE_HDR_WSI=1`
   2. For Wine runners
       - Add environment variable `DXVK_HDR=1`
   4. For Proton runners only (GE-Proton10-1 or newer)


### PR DESCRIPTION
As of [NVIDIA stable driver 595.58.03](https://forums.developer.nvidia.com/t/595-release-feedback-discussion/362561/5?u=ifaigios), `ENABLE_HDR_WSI` is no longer needed.
